### PR TITLE
Implement report tab UI and controller export

### DIFF
--- a/controllers/report_controller.py
+++ b/controllers/report_controller.py
@@ -1,3 +1,7 @@
+from tkinter import messagebox
+from tkinter.filedialog import asksaveasfilename
+
+
 class ReportController:
     """Controller for reports and history."""
 
@@ -11,11 +15,18 @@ class ReportController:
 
     def generate_report(self):
         """Generate report using supply history."""
-        records = self.history_service.list_all()
-        if self.report_service is not None:
-            self.report_service.generate(records)
+        rows = self.history_service.list_all()
+        if not rows:
+            messagebox.showinfo("Report", "No supply history available")
+            return
+        path = asksaveasfilename(
+            defaultextension=".csv",
+            filetypes=[("CSV", "*.csv"), ("PDF", "*.pdf")],
+        )
+        if path:
+            kind = "pdf" if path.endswith(".pdf") else "csv"
+            self.report_service.export(kind, rows, path)
 
     def show_supply_history(self):
         """Refresh the view with supply history."""
-        if self.view is not None:
-            self.view.refresh(self.history_service.list_all())
+        self.view.refresh(self.history_service.list_all())

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -5,3 +5,43 @@ class ReportService:
         """Placeholder for report generation."""
         # For now, just return the records
         return records
+
+    def export(self, kind: str, rows: list[dict], path: str) -> None:
+        """Export rows to CSV or PDF (text-based placeholder)."""
+        if kind == "csv":
+            self._export_csv(rows, path)
+        elif kind == "pdf":
+            self._export_pdf(rows, path)
+        else:
+            raise ValueError(f"Unsupported format: {kind}")
+
+    def _export_csv(self, rows: list[dict], path: str) -> None:
+        import csv
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if rows:
+                writer.writerow(rows[0].keys())
+            for row in rows:
+                writer.writerow([row.get(k, "") for k in rows[0].keys()])
+
+    def _export_pdf(self, rows: list[dict], path: str) -> None:
+        """Very basic PDF export using plain text when FPDF is unavailable."""
+        try:
+            from fpdf import FPDF
+        except Exception:
+            # Fallback: write plain text with .pdf extension
+            with open(path, "w", encoding="utf-8") as f:
+                for row in rows:
+                    line = ", ".join(str(v) for v in row.values())
+                    f.write(line + "\n")
+            return
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        if rows:
+            pdf.cell(200, 10, txt=", ".join(rows[0].keys()), ln=1)
+        for row in rows:
+            pdf.cell(200, 10, txt=", ".join(str(v) for v in row.values()), ln=1)
+        pdf.output(path)

--- a/ui/reports_tab.py
+++ b/ui/reports_tab.py
@@ -1,10 +1,49 @@
 
-from tkinter import ttk, messagebox
+from tkinter import ttk
+
 
 class ReportsTab(ttk.Frame):
+    """UI tab for reports and supply history preview."""
+
     def __init__(self, parent):
         super().__init__(parent)
-        lbl = ttk.Label(self, text="ReportsTab – UI TODO")
-        lbl.pack(pady=20)
-    def set_controller(self, ctrl): 
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(fill="x", pady=5)
+
+        ttk.Button(
+            btn_frame,
+            text="Generate report",
+            command=lambda: self.ctrl.generate_report(),
+        ).pack(side="left", padx=5)
+
+        ttk.Button(
+            btn_frame,
+            text="Supply history",
+            command=lambda: self.ctrl.show_supply_history(),
+        ).pack(side="left", padx=5)
+
+        self.table = ttk.Treeview(
+            self,
+            columns=("id", "supplier", "component", "qty", "date"),
+            show="headings",
+        )
+        self.table.heading("id", text="ID")
+        self.table.heading("supplier", text="Supplier")
+        self.table.heading("component", text="Component")
+        self.table.heading("qty", text="Qty")
+        self.table.heading("date", text="Date")
+        self.table.pack(fill="both", expand=True)
+
+    def set_controller(self, ctrl):
         self.ctrl = ctrl
+
+    def refresh(self, rows: list[dict]):
+        for row in self.table.get_children():
+            self.table.delete(row)
+        for r in rows:
+            self.table.insert(
+                "",
+                "end",
+                iid=r.get("id"),
+                values=(r.get("id"), r.get("supplier"), r.get("component"), r.get("qty"), r.get("date")),
+            )


### PR DESCRIPTION
## Summary
- flesh out reports tab UI
- add CSV/PDF export stubs in report service
- implement save-to-file logic in report controller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488045a89483288197e6b614a9da2c