### PR TITLE
Implement warehouse expense registration UI

### DIFF
--- a/controllers/warehouse_controller.py
+++ b/controllers/warehouse_controller.py
@@ -10,10 +10,13 @@ class WarehouseController:
 
     def show_stock(self):
         """Load current stock data into the view."""
-        if self.view is not None and self.service is not None:
-            self.view.refresh(self.service.list_all())
+        self.view.refresh(self.service.list_all())
 
     def register_expense(self):
-        """Placeholder for registering component usage."""
-        # Real logic would adjust stock based on user input.
-        self.show_stock()
+        """Register a component usage expense."""
+        dto = {
+            "component_id": self.view.component_id_var.get(),
+            "qty": -abs(self.view.qty_var.get()),
+        }
+        self.service.create(dto)
+        self.view.refresh(self.service.list_all())

--- a/ui/warehouse_tab.py
+++ b/ui/warehouse_tab.py
@@ -1,11 +1,19 @@
 
-from tkinter import ttk
+from tkinter import ttk, IntVar
 
 class WarehouseTab(ttk.Frame):
     """UI for viewing stock levels and registering expenses."""
 
     def __init__(self, parent):
         super().__init__(parent)
+        self.qty_var = IntVar()
+        self.component_id_var = IntVar()
+        form = ttk.Frame(self)
+        form.pack(fill="x", pady=5)
+        ttk.Label(form, text="Component ID:").grid(row=0, column=0, padx=5)
+        ttk.Entry(form, textvariable=self.component_id_var).grid(row=0, column=1, padx=5)
+        ttk.Label(form, text="Qty:").grid(row=0, column=2, padx=5)
+        ttk.Entry(form, textvariable=self.qty_var).grid(row=0, column=3, padx=5)
 
         btn_frame = ttk.Frame(self)
         btn_frame.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- add component ID and quantity inputs in Warehouse tab
- handle stock refresh and expense registration in `WarehouseController`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489107a2f88328b6b1eea539387070