### PR TITLE
Enhance DAO update/delete flexibility

### DIFF
--- a/dao/component_dao.py
+++ b/dao/component_dao.py
@@ -34,24 +34,38 @@ class ComponentDAO:
             )
         return cur.lastrowid
 
-    def update(self, component: dict) -> bool:
-        """Update component by ID using dict fields."""
+    def update(self, component: int | dict, values: dict | None = None) -> bool:
+        """Update component by ID using dict fields.
+
+        Can be called either with a full component ``dict`` containing an ``id``
+        or with a component ``id`` and a ``values`` dictionary.
+        """
+        if isinstance(component, int):
+            component_id = component
+            if values is None:
+                raise ValueError("values must be provided when updating by id")
+            data = values
+        else:
+            data = component
+            component_id = data.get("id")
+
         with self.conn:
             cur = self.conn.execute(
                 """UPDATE components
                        SET name = ?, unit = ?, quantity_in_stock = ?
                      WHERE id = ?""",
                 (
-                    component.get("name"),
-                    component.get("unit"),
-                    component.get("quantity_in_stock", 0),
-                    component.get("id"),
+                    data.get("name"),
+                    data.get("unit"),
+                    data.get("quantity_in_stock", 0),
+                    component_id,
                 ),
             )
         return cur.rowcount > 0
 
-    def delete(self, component_id: int) -> bool:
-        """Delete component by ID."""
+    def delete(self, component: int | dict) -> bool:
+        """Delete component by ID or component dict."""
+        component_id = component if isinstance(component, int) else component.get("id")
         with self.conn:
             cur = self.conn.execute(
                 "DELETE FROM components WHERE id = ?",

--- a/dao/supplier_dao.py
+++ b/dao/supplier_dao.py
@@ -28,21 +28,35 @@ class SupplierDAO:
             )
         return cur.lastrowid
 
-    def update(self, supplier: dict) -> bool:
-        """Update supplier by ID using dict fields."""
+    def update(self, supplier: int | dict, values: dict | None = None) -> bool:
+        """Update supplier by ID using dict fields.
+
+        Accepts either a supplier ``dict`` containing the ``id`` or a supplier
+        ``id`` with a ``values`` dictionary of updated fields.
+        """
+        if isinstance(supplier, int):
+            supplier_id = supplier
+            if values is None:
+                raise ValueError("values must be provided when updating by id")
+            data = values
+        else:
+            data = supplier
+            supplier_id = data.get("id")
+
         with self.conn:
             cur = self.conn.execute(
                 "UPDATE suppliers SET name = ?, contact_info = ? WHERE id = ?",
                 (
-                    supplier.get("name"),
-                    supplier.get("contact_info"),
-                    supplier.get("id"),
+                    data.get("name"),
+                    data.get("contact_info"),
+                    supplier_id,
                 ),
             )
         return cur.rowcount > 0
 
-    def delete(self, supplier_id: int) -> bool:
-        """Delete supplier by ID."""
+    def delete(self, supplier: int | dict) -> bool:
+        """Delete supplier by ID or supplier dict."""
+        supplier_id = supplier if isinstance(supplier, int) else supplier.get("id")
         with self.conn:
             cur = self.conn.execute(
                 "DELETE FROM suppliers WHERE id = ?",

--- a/tests/dao/test_component_dao.py
+++ b/tests/dao/test_component_dao.py
@@ -18,3 +18,16 @@ def test_update_quantity(dao):
     dao.update_quantity(comp_id, 3)
     row = dao.select_by_id(comp_id)
     assert row["quantity_in_stock"] == 8
+
+
+def test_update_by_id(dao):
+    comp_id = dao.insert({"name": "Screw", "unit": "pcs", "quantity_in_stock": 1})
+    dao.update(comp_id, {"name": "Screw", "unit": "pcs", "quantity_in_stock": 2})
+    row = dao.select_by_id(comp_id)
+    assert row["quantity_in_stock"] == 2
+
+
+def test_delete_with_dict(dao):
+    comp_id = dao.insert({"name": "Washer", "unit": "pcs", "quantity_in_stock": 0})
+    assert dao.delete({"id": comp_id}) is True
+    assert dao.select_by_id(comp_id) is None

--- a/tests/dao/test_supplier_dao.py
+++ b/tests/dao/test_supplier_dao.py
@@ -1,0 +1,27 @@
+import pytest
+from db.database import get_connection
+from dao.supplier_dao import SupplierDAO
+
+@pytest.fixture
+def dao():
+    conn = get_connection(":memory:")
+    return SupplierDAO(conn)
+
+
+def test_insert_and_select(dao):
+    supplier_id = dao.insert({"name": "ACME", "contact_info": "info"})
+    row = dao.select_by_id(supplier_id)
+    assert row["name"] == "ACME"
+
+
+def test_update_by_id(dao):
+    supplier_id = dao.insert({"name": "Old", "contact_info": ""})
+    dao.update(supplier_id, {"name": "New", "contact_info": ""})
+    row = dao.select_by_id(supplier_id)
+    assert row["name"] == "New"
+
+
+def test_delete_with_dict(dao):
+    supplier_id = dao.insert({"name": "Temp", "contact_info": ""})
+    assert dao.delete({"id": supplier_id}) is True
+    assert dao.select_by_id(supplier_id) is None


### PR DESCRIPTION
## Summary
- support updating/deleting using either IDs or DTO dicts in DAOs
- test new DAO behaviour

## Testing
- `pip install tk`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684894dae8c883288784321eaad237af