### PR TITLE
Add headless skip for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import pytest
+
+if not os.environ.get("DISPLAY") and os.name != "nt":
+    pytest.skip("Skipping GUI tests on headless", allow_module_level=True)


### PR DESCRIPTION
## Summary
- add a pytest conftest that skips when running on headless environments

## Testing
- `pytest -q` *(fails: Skipped: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_684895dc6e208328afe4445c9b2f40ec