### PR TITLE
Implement warehouse expense validation

### DIFF
--- a/controllers/warehouse_controller.py
+++ b/controllers/warehouse_controller.py
@@ -1,4 +1,7 @@
 
+from tkinter import messagebox
+
+
 class WarehouseController:
     """Controller for warehouse-related actions."""
 
@@ -10,13 +13,30 @@ class WarehouseController:
 
     def show_stock(self):
         """Load current stock data into the view."""
-        self.view.refresh(self.service.list_all())
+        rows = self.service.list_all()
+        self.view.refresh(rows)
+        if not rows:
+            messagebox.showinfo("Stock", "No components in stock")
 
     def register_expense(self):
         """Register a component usage expense."""
-        dto = {
-            "component_id": self.view.component_id_var.get(),
-            "qty": -abs(self.view.qty_var.get()),
-        }
-        self.service.create(dto)
-        self.view.refresh(self.service.list_all())
+        try:
+            component_id = int(self.view.component_id_var.get())
+            qty = int(self.view.qty_var.get())
+        except (TypeError, ValueError):
+            messagebox.showwarning("Validation", "Component ID and quantity must be numbers")
+            return
+
+        if component_id <= 0 or qty <= 0:
+            messagebox.showwarning(
+                "Validation", "Component ID and quantity must be positive"
+            )
+            return
+
+        # Adjust stock by negative quantity to represent an expense
+        self.service.adjust_stock(component_id, -qty)
+
+        # Refresh the stock view
+        self.show_stock()
+
+        messagebox.showinfo("Expense", "Expense registered")


### PR DESCRIPTION
## Summary
- handle invalid data in WarehouseController.register_expense
- show message on empty stock
- update stock using service.adjust_stock

## Testing
- `pytest -q` *(fails: Skipped: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849a62702ac832880f4fb03fe76e812