### PR TITLE
Add warehouse expense support

### DIFF
--- a/controllers/warehouse_controller.py
+++ b/controllers/warehouse_controller.py
@@ -1,3 +1,5 @@
+from tkinter import messagebox
+
 
 class WarehouseController:
     """Controller for warehouse-related actions."""
@@ -14,9 +16,15 @@ class WarehouseController:
 
     def register_expense(self):
         """Register a component usage expense."""
-        dto = {
-            "component_id": self.view.component_id_var.get(),
-            "qty": -abs(self.view.qty_var.get()),
-        }
-        self.service.create(dto)
+        component_id = self.view.component_id_var.get()
+        qty = self.view.qty_var.get()
+
+        if component_id <= 0 or qty <= 0:
+            messagebox.showerror(
+                "Validation", "Component ID and quantity must be positive integers"
+            )
+            return
+
+        self.service.register_expense(component_id, qty)
         self.view.refresh(self.service.list_all())
+        messagebox.showinfo("Expense", "Expense registered")

--- a/services/warehouse_service.py
+++ b/services/warehouse_service.py
@@ -7,3 +7,7 @@ class WarehouseService(ComponentService):
 
     def __init__(self, dao: WarehouseDAO):
         super().__init__(dao)
+
+    def register_expense(self, component_id: int, qty: int) -> None:
+        """Decrease stock for the given component by ``qty``."""
+        self.adjust_stock(component_id, -abs(qty))


### PR DESCRIPTION
## Summary
- allow decreasing stock via WarehouseService.register_expense
- validate input and show messages from WarehouseController

## Testing
- `pytest -q` *(fails: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7037d988328b720e47d9d6e5309