### PR TITLE
Improve warehouse expense functionality

### DIFF
--- a/controllers/warehouse_controller.py
+++ b/controllers/warehouse_controller.py
@@ -1,3 +1,5 @@
+from tkinter import messagebox
+
 
 class WarehouseController:
     """Controller for warehouse-related actions."""
@@ -14,9 +16,15 @@ class WarehouseController:
 
     def register_expense(self):
         """Register a component usage expense."""
-        dto = {
-            "component_id": self.view.component_id_var.get(),
-            "qty": -abs(self.view.qty_var.get()),
-        }
-        self.service.create(dto)
+        component_id = self.view.component_id_var.get()
+        qty = self.view.qty_var.get()
+
+        if component_id <= 0 or qty <= 0:
+            messagebox.showerror(
+                "Validation", "Component ID and quantity must be positive integers"
+            )
+            return
+
+        self.service.register_expense(component_id, qty)
         self.view.refresh(self.service.list_all())
+        messagebox.showinfo("Expense", "Expense registered")

--- a/dao/warehouse_dao.py
+++ b/dao/warehouse_dao.py
@@ -6,3 +6,7 @@ class WarehouseDAO(ComponentDAO):
 
     def __init__(self, conn):
         super().__init__(conn)
+
+    def register_expense(self, component_id: int, qty: int) -> None:
+        """Decrease stock for ``component_id`` by ``qty``."""
+        self.update_quantity(component_id, -abs(qty))

--- a/services/warehouse_service.py
+++ b/services/warehouse_service.py
@@ -7,3 +7,7 @@ class WarehouseService(ComponentService):
 
     def __init__(self, dao: WarehouseDAO):
         super().__init__(dao)
+
+    def register_expense(self, component_id: int, qty: int) -> None:
+        """Decrease stock for ``component_id`` by ``qty``."""
+        self.dao.register_expense(component_id, qty)

--- a/tests/dao/test_warehouse_dao.py
+++ b/tests/dao/test_warehouse_dao.py
@@ -1,0 +1,11 @@
+from db.database import get_connection
+from dao.warehouse_dao import WarehouseDAO
+
+
+def test_register_expense():
+    conn = get_connection(":memory:")
+    dao = WarehouseDAO(conn)
+    comp_id = dao.insert({"name": "Bolt", "unit": "pcs", "quantity_in_stock": 5})
+    dao.register_expense(comp_id, 2)
+    row = dao.select_by_id(comp_id)
+    assert row["quantity_in_stock"] == 3

--- a/tests/service/test_warehouse_service.py
+++ b/tests/service/test_warehouse_service.py
@@ -1,0 +1,17 @@
+from db.database import get_connection
+from dao.warehouse_dao import WarehouseDAO
+from services.warehouse_service import WarehouseService
+
+
+def create_service():
+    conn = get_connection(":memory:")
+    dao = WarehouseDAO(conn)
+    return WarehouseService(dao)
+
+
+def test_register_expense():
+    service = create_service()
+    comp_id = service.create({"name": "Bolt", "unit": "pcs", "quantity_in_stock": 5})
+    service.register_expense(comp_id, 2)
+    row = service.get(comp_id)
+    assert row["quantity_in_stock"] == 3


### PR DESCRIPTION
## Summary
- implement expense handling in DAO and service
- validate and execute expense registration in controller
- add new unit tests for warehouse layer

## Testing
- `pytest -q` *(fails: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7037d988328b720e47d9d6e5309