### PR TITLE
Implement warehouse expense tracking

### DIFF
--- a/controllers/warehouse_controller.py
+++ b/controllers/warehouse_controller.py
@@ -1,3 +1,5 @@
+from tkinter import messagebox
+
 
 class WarehouseController:
     """Controller for warehouse-related actions."""
@@ -14,9 +16,20 @@ class WarehouseController:
 
     def register_expense(self):
         """Register a component usage expense."""
-        dto = {
-            "component_id": self.view.component_id_var.get(),
-            "qty": -abs(self.view.qty_var.get()),
-        }
-        self.service.create(dto)
+        component_id = self.view.component_id_var.get()
+        qty = self.view.qty_var.get()
+
+        if component_id <= 0 or qty <= 0:
+            messagebox.showerror(
+                "Validation", "Component ID and quantity must be positive"
+            )
+            return
+
+        try:
+            self.service.register_expense(component_id, qty)
+        except ValueError as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+
         self.view.refresh(self.service.list_all())
+        messagebox.showinfo("Success", "Expense registered")

--- a/dao/warehouse_dao.py
+++ b/dao/warehouse_dao.py
@@ -6,3 +6,27 @@ class WarehouseDAO(ComponentDAO):
 
     def __init__(self, conn):
         super().__init__(conn)
+
+    def register_expense(self, component_id: int, qty: int) -> None:
+        """Register usage of a component and log it into supply history."""
+        with self.conn as con:
+            cur = con.execute(
+                "SELECT quantity_in_stock FROM components WHERE id = ?",
+                (component_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise ValueError("Component not found")
+            current_qty = row[0]
+            if qty > current_qty:
+                raise ValueError("Insufficient stock")
+
+            con.execute(
+                "UPDATE components SET quantity_in_stock = quantity_in_stock - ? WHERE id = ?",
+                (qty, component_id),
+            )
+
+            con.execute(
+                "INSERT INTO supply_history(component_id, qty, date) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                (component_id, qty),
+            )

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,13 @@
+-- SQLite seed for demo
+INSERT INTO suppliers(name, contact_info) VALUES
+ ('ACME Ltd', 'acme@example.com'),
+ ('Bolt & Nut', 'sales@bn.com');
+
+INSERT INTO components(name, unit, quantity_in_stock) VALUES
+ ('Screw M3', 'pcs', 500),
+ ('Nut M3',   'pcs', 800);
+
+-- Simulate one expense
+UPDATE components SET quantity_in_stock = quantity_in_stock - 100 WHERE name='Screw M3';
+INSERT INTO supply_history(supplier_id, component_id, qty, date)
+VALUES (1, 1, 100, datetime('now'));

--- a/services/warehouse_service.py
+++ b/services/warehouse_service.py
@@ -7,3 +7,8 @@ class WarehouseService(ComponentService):
 
     def __init__(self, dao: WarehouseDAO):
         super().__init__(dao)
+
+    def register_expense(self, component_id: int, qty: int) -> None:
+        """Delegate expense registration to the DAO."""
+        self.dao.register_expense(component_id, qty)
+

--- a/ui/reports_tab.py
+++ b/ui/reports_tab.py
@@ -38,6 +38,7 @@ class ReportsTab(ttk.Frame):
         self.ctrl = ctrl
 
     def refresh(self, rows: list[dict]):
+        rows = rows or []
         for row in self.table.get_children():
             self.table.delete(row)
         for r in rows:
@@ -45,5 +46,11 @@ class ReportsTab(ttk.Frame):
                 "",
                 "end",
                 iid=r.get("id"),
-                values=(r.get("id"), r.get("supplier"), r.get("component"), r.get("qty"), r.get("date")),
+                values=(
+                    r.get("id"),
+                    r.get("supplier"),
+                    r.get("component"),
+                    r.get("qty"),
+                    r.get("date"),
+                ),
             )


### PR DESCRIPTION
## Summary
- add register_expense logic to `WarehouseController`
- implement `WarehouseDAO.register_expense` with stock checks and history log
- expose new DAO functionality via `WarehouseService.register_expense`
- ensure ReportsTab refresh works with empty lists
- provide SQL seed script for demo data

## Testing
- `pytest -q` *(fails: Skipped: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca1d77e48328bf45e405a10ac10b