### PR TITLE
Implement supplier supply history view

### DIFF
--- a/controllers/suppliers_controller.py
+++ b/controllers/suppliers_controller.py
@@ -1,4 +1,5 @@
 from controllers.supplier_controller import SupplierController
+from tkinter import messagebox, Toplevel, ttk
 
 
 class SuppliersController(SupplierController):
@@ -7,3 +8,28 @@ class SuppliersController(SupplierController):
     def list_all_suppliers(self) -> list[tuple[int, str, str]]:
         """Return all suppliers ordered by ``id`` ascending."""
         return self.facade.supplier_dao.get_all()
+
+    def show_supply_history(self, supplier_id: int) -> None:
+        """Display supply history for the given supplier in a modal window."""
+        rows = self.facade.supply_dao.get_history_by_supplier(supplier_id)
+        if not rows:
+            messagebox.showinfo("Report", "No supply history available")
+            return
+
+        modal = Toplevel(self.view)
+        modal.title("Supply history")
+        modal.resizable(True, True)
+        modal.grab_set()
+
+        columns = ("date", "component", "qty")
+        tree = ttk.Treeview(modal, columns=columns, show="headings")
+        for col in columns:
+            tree.heading(col, text=col)
+            tree.column(col, anchor="center")
+        for date, component, qty in rows:
+            tree.insert("", "end", values=(date, component, qty))
+
+        scrollbar = ttk.Scrollbar(modal, orient="vertical", command=tree.yview)
+        tree.configure(yscrollcommand=scrollbar.set)
+        tree.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")


### PR DESCRIPTION
## Summary
- expose Tkinter utilities in `SuppliersController`
- implement `show_supply_history` to display a supplier's supply history

## Testing
- `pytest -q` *(fails: Skipped: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849d29e033c8328b560f745aa69262e