### PR TITLE
Add seed SQL for supply history example

### DIFF
--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,12 @@
+INSERT INTO suppliers(name, contact_info) VALUES
+ ('ACME Ltd','acme@mail.com'),
+ ('Bolt & Nut','sales@bn.com');
+
+INSERT INTO components(name, unit, quantity_in_stock) VALUES
+ ('Screw M3','pcs',500),
+ ('Nut M3','pcs',800),
+ ('Bolt M5','pcs',300);
+
+-- add one supply record to history
+INSERT INTO supply_history(supplier_id, component_id, qty, date)
+VALUES (1, 1, 200, datetime('now','-2 days'));


### PR DESCRIPTION
## Summary
- add a new `seed.sql` file under the `db` directory
  - seeds suppliers, components and supply history data

## Testing
- `pytest -q` *(fails: Skipped: Skipping GUI tests on headless)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec7382e883289124c8d2fe6f3c59